### PR TITLE
Edit existing todos

### DIFF
--- a/client/actions/Todo.js
+++ b/client/actions/Todo.js
@@ -49,7 +49,10 @@ export const updateTodo = (id, todo) => dispatch => {
 	dispatch({ type: REQUEST });
 	return fetch(`${config.api}/api/todos/${id}`, {
 		method: 'PUT',
-		body: JSON.stringify(todo)
+		body: JSON.stringify(todo),
+		headers: {
+			'Content-Type': 'application/json'
+		}
 	}).then(res => res.json())
 		.then(json => dispatch({ type: UPDATE_TODO, id, todo: json }))
 		.catch(error => dispatch({ type: ERROR, error }));

--- a/client/components/lib/modals/Todo/Preview/Header/index.jsx
+++ b/client/components/lib/modals/Todo/Preview/Header/index.jsx
@@ -12,7 +12,7 @@ class Header extends React.Component {
 					editing
 						? <Field
 							type="text"
-							name="todoName"
+							name="todo"
 							component="input"
 						/>
 						: todo.todo

--- a/client/components/lib/modals/Todo/index.jsx
+++ b/client/components/lib/modals/Todo/index.jsx
@@ -46,7 +46,8 @@ class Todo extends React.Component {
 
 	handleSubmit(data) {
 		const id = this.props.todo._id;
-		this.props.onUpdate(id, data);
+		let newTodo = Object.assign(this.props.todo, data); // merge oldtodo and data
+		this.props.onUpdate(id, newTodo);
 	}
 
 	toggleEditing() {

--- a/client/containers/lib/modals/Todo/index.js
+++ b/client/containers/lib/modals/Todo/index.js
@@ -6,7 +6,7 @@ import { promptDelete as onDelete, updateTodo as onUpdate } from '../../../../ac
 const mapStateToProps = state => ({
 	todo: state.todos.selected,
 	initialValues: {
-		todoName: state.todos.selected.todo,
+		todo: state.todos.selected.todo,
 		label: state.todos.selected.label,
 		status: state.todos.selected.status
 	}


### PR DESCRIPTION
Fixes #1 

The application would fail whenever we try to edit an existing todo. The reason why it would fail was that the request body (for update request) was always an empty object. Since javascript considers an empty object to be "truthy," the code would try to access fields in an empty object which in turn causes the server to crash. In order to fix this, we add a Content-type field to the update request which would let the backend know to look out for the JSON object. 

However, this, in turn, caused another issue where there were inconsistencies between created todos and edited todos. The reason behind this was because the AddTodo form and the Edit todo form had different names which caused the request body to have different values. The edit form does not know about attributes such as `._id`. In order to fix this, we normalize the name of the title which will be "todo," and merge the old todo with the newly created todo with Object.assign